### PR TITLE
Bump version numbers for After Effects and Photoshop plug-ins (#514)

### DIFF
--- a/src/aftereffects/vc/vc9/OpenColorABI.h
+++ b/src/aftereffects/vc/vc9/OpenColorABI.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Makefile configuration options
 #define OCIO_NAMESPACE OpenColorIO
 #define OCIO_USE_BOOST_PTR 1
-#define OCIO_VERSION "1.0.9"
+#define OCIO_VERSION "1.1.0"
 #define OCIO_VERSION_NS v1
 
 /* Version as a single 4-byte hex number, e.g. 0x01050200 == 1.5.2
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    this will reflect the original API version number.
    */
 #define OCIO_VERSION_HEX ((1 << 24) | \
-                          (0 << 16) | \
-                          (9 <<  8))
+                          (1 << 16) | \
+                          (0 <<  8))
 
 
 // Namespace / version mojo

--- a/src/aftereffects/vc/vc9/OpenColorIO.vcproj
+++ b/src/aftereffects/vc/vc9/OpenColorIO.vcproj
@@ -749,6 +749,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\..\core\Platform.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\..\src\core\Processor.cpp"
 				>
 			</File>

--- a/src/aftereffects/xcode/OpenColorABI.h
+++ b/src/aftereffects/xcode/OpenColorABI.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Makefile configuration options
 #define OCIO_NAMESPACE OpenColorIO
 #define OCIO_USE_BOOST_PTR 0
-#define OCIO_VERSION "1.0.9"
+#define OCIO_VERSION "1.1.0"
 #define OCIO_VERSION_NS v1
 
 /* Version as a single 4-byte hex number, e.g. 0x01050200 == 1.5.2
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    this will reflect the original API version number.
    */
 #define OCIO_VERSION_HEX ((1 << 24) | \
-                          (0 << 16) | \
-                          (9 <<  8))
+                          (1 << 16) | \
+                          (0 <<  8))
 
 
 // Namespace / version mojo

--- a/src/aftereffects/xcode/OpenColorIO.xcodeproj/project.pbxproj
+++ b/src/aftereffects/xcode/OpenColorIO.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2A7CACBF15536CD700F52C98 /* NoOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A7CACB915536CD700F52C98 /* NoOps.h */; };
 		2A7CACC015536CD700F52C98 /* OpOptimizers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7CACBA15536CD700F52C98 /* OpOptimizers.cpp */; };
 		2A7F20D31E2F17D2003428D7 /* FileFormatCDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7F20D21E2F17D2003428D7 /* FileFormatCDL.cpp */; };
+		2AA3F61E2028C82D004F36B7 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AA3F61D2028C82D004F36B7 /* Platform.cpp */; };
 		2ACB3D001CC074A200134356 /* Display.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2ACB3CFE1CC074A200134356 /* Display.cpp */; };
 		2ACB3D011CC074A200134356 /* Display.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ACB3CFF1CC074A200134356 /* Display.h */; };
 		2ACF56CC14776A1E00991ED5 /* AllocationOp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2ACF567614776A1E00991ED5 /* AllocationOp.cpp */; };
@@ -110,6 +111,7 @@
 		2A7CACB915536CD700F52C98 /* NoOps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NoOps.h; sourceTree = "<group>"; };
 		2A7CACBA15536CD700F52C98 /* OpOptimizers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OpOptimizers.cpp; sourceTree = "<group>"; };
 		2A7F20D21E2F17D2003428D7 /* FileFormatCDL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileFormatCDL.cpp; sourceTree = "<group>"; };
+		2AA3F61D2028C82D004F36B7 /* Platform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Platform.cpp; sourceTree = "<group>"; };
 		2ACB3CFE1CC074A200134356 /* Display.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Display.cpp; sourceTree = "<group>"; };
 		2ACB3CFF1CC074A200134356 /* Display.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Display.h; sourceTree = "<group>"; };
 		2ACF567114776A0A00991ED5 /* libOpenColorIO.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOpenColorIO.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -231,6 +233,7 @@
 		2ACF567514776A1E00991ED5 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				2AA3F61D2028C82D004F36B7 /* Platform.cpp */,
 				2ACB3CFE1CC074A200134356 /* Display.cpp */,
 				2ACB3CFF1CC074A200134356 /* Display.h */,
 				2ACF567614776A1E00991ED5 /* AllocationOp.cpp */,
@@ -497,6 +500,7 @@
 				2A7CACC015536CD700F52C98 /* OpOptimizers.cpp in Sources */,
 				2ACB3D001CC074A200134356 /* Display.cpp in Sources */,
 				2A7F20D31E2F17D2003428D7 /* FileFormatCDL.cpp in Sources */,
+				2AA3F61E2028C82D004F36B7 /* Platform.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/photoshop/OpenColorIO_PS_Version.h
+++ b/src/photoshop/OpenColorIO_PS_Version.h
@@ -31,14 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #define OpenColorIO_PS_Major_Version 1
-#define OpenColorIO_PS_Minor_Version 0
-#define OpenColorIO_PS_Version_String "1.0"
-#define OpenColorIO_PS_Beta_String "Beta 4"
+#define OpenColorIO_PS_Minor_Version 1
+#define OpenColorIO_PS_Version_String "1.1.0"
 #define OpenColorIO_PS_Build_Date __DATE__
-#define OpenColorIO_PS_Build_Date_Manual "13 February 2017"
-#define OpenColorIO_PS_Build_Complete_Manual "v1.0 Beta 4 - " OpenColorIO_PS_Build_Date
-#define OpenColorIO_PS_Copyright_Year "2017"
-#define OpenColorIO_PS_Build_Year "2017"
+#define OpenColorIO_PS_Build_Date_Manual "5 February 2018"
+#define OpenColorIO_PS_Build_Complete_Manual "v1.1.0 - " OpenColorIO_PS_Build_Date
+#define OpenColorIO_PS_Copyright_Year "2018"
+#define OpenColorIO_PS_Build_Year "2018"
 
 #define OpenColorIO_PS_Description "OpenColorIO"
 

--- a/src/photoshop/mac/OpenColorIO_PS_Dialog_Cocoa.mm
+++ b/src/photoshop/mac/OpenColorIO_PS_Dialog_Cocoa.mm
@@ -153,9 +153,7 @@ void OpenColorIO_PS_About(const void *plugHndl, const void *mwnd)
 
     const std::string endl = "\n";
 
-    std::string text = std::string("OpenColorIO PS") + endl +
-                        OpenColorIO_PS_Beta_String + endl +
-                        __DATE__ + endl +
+    std::string text = __DATE__ + endl +
                         endl +
                         "OCIO version " + OCIO::GetVersion();
                         

--- a/src/photoshop/win/OpenColorIO_PS_Dialogs_Win.cpp
+++ b/src/photoshop/win/OpenColorIO_PS_Dialogs_Win.cpp
@@ -1027,8 +1027,7 @@ void OpenColorIO_PS_About(const void *plugHndl, const void *mwnd)
 	
 	const std::string endl = "\n";
 
-	std::string text = std::string("OpenColorIO PS") + endl +
-						OpenColorIO_PS_Beta_String + endl +
+	std::string text = std::string("OpenColorIO") + endl +
 						__DATE__ + endl +
 						endl +
 						"OCIO version " + OCIO::GetVersion();


### PR DESCRIPTION
* Stop accepting .ccc files while we don't have a way to get the ID

* Getting video space buffers for Premiere

* Bump After Effects and Photoshop plug-ins to 1.1.0

* Update Mac AE and PS plug-in builds

* Update Windows AE and PS plug-in builds